### PR TITLE
Fix unknown host bug in Sneeze.configure

### DIFF
--- a/sneeze/nose_interface.py
+++ b/sneeze/nose_interface.py
@@ -109,7 +109,7 @@ class Sneeze(Plugin):
                     rerun_execution_ids = options.case_execution_reruns
                 self.tissue = Tissue(options.reporting_db_config, options.test_cycle_name,
                                      options.test_cycle_description, environment,
-                                     socket.gethostbyaddr(socket.gethostname())[0],
+                                     socket.gethostbyaddr(socket.gethostbyname(socket.gethostname()))[0],
                                      ' '.join(sys.argv), test_cycle_id=test_cycle_id,
                                      rerun_execution_ids=rerun_execution_ids)
                 noseconfig.test_cycle_id = self.tissue.test_cycle.id


### PR DESCRIPTION
Added a call to socket.gethostbyname in Sneeze.configure to resolve this.

Traceback (most recent call last):
  File /Users/samfonseca/dev/envs/sneeze/bin/nosetests, line 9, in <module>
    load_entry_point('nose-for-sneeze==1.3.0', 'console_scripts', 'nosetests')()
  File /Users/samfonseca/dev/envs/sneeze/lib/python2.7/site-packages/nose-1.3.6-py2.7.egg/nose/core.py, line 121, in **init**
    *_extra_args)
  File /Users/samfonseca/.pyenv/versions/2.7.9/lib/python2.7/unittest/main.py, line 94, in **init**
    self.parseArgs(argv)
  File /Users/samfonseca/dev/envs/sneeze/lib/python2.7/site-packages/nose-1.3.6-py2.7.egg/nose/core.py, line 145, in parseArgs
    self.config.configure(argv, doc=self.usage())
  File /Users/samfonseca/dev/envs/sneeze/lib/python2.7/site-packages/nose-1.3.6-py2.7.egg/nose/config.py, line 346, in configure
    self.plugins.configure(options, self)
  File /Users/samfonseca/dev/envs/sneeze/lib/python2.7/site-packages/nose-1.3.6-py2.7.egg/nose/plugins/manager.py, line 284, in configure
    cfg(options, config)
  File /Users/samfonseca/dev/envs/sneeze/lib/python2.7/site-packages/nose-1.3.6-py2.7.egg/nose/plugins/manager.py, line 99, in **call**
    return self.call(_arg, *_kw)
  File /Users/samfonseca/dev/envs/sneeze/lib/python2.7/site-packages/nose-1.3.6-py2.7.egg/nose/plugins/manager.py, line 167, in simple
    result = meth(_arg, **kw)
  File build/bdist.macosx-10.10-x86_64/egg/sneeze/nose_interface.py, line 125, in configure
socket.herror: [Errno 1] Unknown host
